### PR TITLE
Change *grouping* to *set* for disambiguation

### DIFF
--- a/tensorflow/docs_src/get_started/get_started.md
+++ b/tensorflow/docs_src/get_started/get_started.md
@@ -27,7 +27,7 @@ working internally when you use the more compact higher level API.
 # Tensors
 
 The central unit of data in TensorFlow is the **tensor**. A tensor consists of a
-set of primitive values shaped into an array of any number of dimensions. A
+grouping of primitive values shaped into an array of any number of dimensions. A
 tensor's **rank** is its number of dimensions. Here are some examples of
 tensors:
 


### PR DESCRIPTION
Hi! When reading "A tensor consists of a set of primitive values shaped into an array", it was ambiguous whether or not the ordering in the array matters. I assume that - at least in some cases - the ordering matters, and that maybe the word "set" could be more clear as something akin to a "grouping".

Maybe worth considering? Thanks for taking the time to read this! 😺 